### PR TITLE
Fix README language links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
 
-[English | [日本語](https://github.com/mcp-router/mcp-router/blob/main/README_ja.md)]
+[English](https://github.com/mcp-router/mcp-router/blob/main/README.md) | [日本語](https://github.com/mcp-router/mcp-router/blob/main/README_ja.md)
 
 </div>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -5,7 +5,7 @@
 
 <div align="center">
 
-[[English](https://github.com/mcp-router/mcp-router/blob/main/README.md) | 日本語]
+[English](https://github.com/mcp-router/mcp-router/blob/main/README.md) | [日本語](https://github.com/mcp-router/mcp-router/blob/main/README_ja.md)
 
 </div>
 


### PR DESCRIPTION
## Summary
- fix English/Japanese link syntax in READMEs

## Testing
- `npm run typecheck` *(fails: Cannot find module 'prism-react-renderer')*